### PR TITLE
Format JSON of expected response in generated test files

### DIFF
--- a/spring-boot-2/src/main/java/org/quickperf/web/spring/testgeneration/ExpectedResponseFileGenerator.java
+++ b/spring-boot-2/src/main/java/org/quickperf/web/spring/testgeneration/ExpectedResponseFileGenerator.java
@@ -12,6 +12,8 @@
  */
 package org.quickperf.web.spring.testgeneration;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import org.quickperf.web.spring.HttpContentType;
 
 class ExpectedResponseFileGenerator {
@@ -24,6 +26,9 @@ class ExpectedResponseFileGenerator {
     TestFile generate(String content, String contentType, String fileNameWithoutExtension) {
         String responseExtension = findExpectedResponseFileExtension(contentType);
         String expectedResponseFileName = fileNameWithoutExtension + "-expected" + responseExtension;
+        if (responseExtension.equals(".json")){
+            content = formatJson(content);
+        }
         return new TestFile(expectedResponseFileName, content);
     }
 
@@ -35,6 +40,18 @@ class ExpectedResponseFileGenerator {
             return ".html";
         }
         return ".txt";
+    }
+
+    private String formatJson(String content){
+        ObjectMapper mapper = new ObjectMapper();
+        try {
+            Object str = mapper.readValue(content, Object.class);
+            String jsonPrettyPrint = mapper.writerWithDefaultPrettyPrinter().writeValueAsString(str);
+            content = jsonPrettyPrint;
+        } catch (JsonProcessingException e) {
+            // do nothing. original content will be used
+        }
+        return content;
     }
 
 }

--- a/spring-boot2-test/src/main/java/org/quickperf/spring/springboottest/controller/JsonWithoutSqlExecutionController.java
+++ b/spring-boot2-test/src/main/java/org/quickperf/spring/springboottest/controller/JsonWithoutSqlExecutionController.java
@@ -26,8 +26,8 @@ public class JsonWithoutSqlExecutionController {
     @GetMapping(HttpUrl.JSON_WITHOUT_SQL)
     public List<PlayerWithTeamName> jsonWithoutSql() {
         PlayerWithTeamName paulPogba = new PlayerWithTeamName("Paul", "Pogba", "Manchester United");
-        PlayerWithTeamName antoineGriezman = new PlayerWithTeamName("Antoine", "Griezman", "Barcelona" );
-        return asList(paulPogba, antoineGriezman);
+        PlayerWithTeamName antoineGriezmann = new PlayerWithTeamName("Antoine", "Griezmann", "Barcelona" );
+        return asList(paulPogba, antoineGriezmann);
     }
 
 }

--- a/spring-boot2-test/src/test/resources/testgen-expected/junit4/json-with-n-plus-one-select/json-with-n-plus-one-select-expected.json
+++ b/spring-boot2-test/src/test/resources/testgen-expected/junit4/json-with-n-plus-one-select/json-with-n-plus-one-select-expected.json
@@ -1,1 +1,9 @@
-[{"firstName":"Paul","lastName":"Pogba","team":"Manchester United"},{"firstName":"Antoine","lastName":"Griezmann","team":"Barcelona"}]
+[ {
+  "firstName" : "Paul",
+  "lastName" : "Pogba",
+  "team" : "Manchester United"
+}, {
+  "firstName" : "Antoine",
+  "lastName" : "Griezmann",
+  "team" : "Barcelona"
+} ]

--- a/spring-boot2-test/src/test/resources/testgen-expected/junit4/json-without-sql/json-without-sql-expected.json
+++ b/spring-boot2-test/src/test/resources/testgen-expected/junit4/json-without-sql/json-without-sql-expected.json
@@ -1,1 +1,9 @@
-[{"firstName":"Paul","lastName":"Pogba","team":"Manchester United"},{"firstName":"Antoine","lastName":"Griezman","team":"Barcelona"}]
+[ {
+  "firstName" : "Paul",
+  "lastName" : "Pogba",
+  "team" : "Manchester United"
+}, {
+  "firstName" : "Antoine",
+  "lastName" : "Griezmann",
+  "team" : "Barcelona"
+} ]

--- a/spring-boot2-test/src/test/resources/testgen-expected/junit5/json-with-n-plus-one-select/json-with-n-plus-one-select-expected.json
+++ b/spring-boot2-test/src/test/resources/testgen-expected/junit5/json-with-n-plus-one-select/json-with-n-plus-one-select-expected.json
@@ -1,1 +1,9 @@
-[{"firstName":"Paul","lastName":"Pogba","team":"Manchester United"},{"firstName":"Antoine","lastName":"Griezmann","team":"Barcelona"}]
+[ {
+  "firstName" : "Paul",
+  "lastName" : "Pogba",
+  "team" : "Manchester United"
+}, {
+  "firstName" : "Antoine",
+  "lastName" : "Griezmann",
+  "team" : "Barcelona"
+} ]

--- a/spring-boot2-test/src/test/resources/testgen-expected/junit5/json-without-sql/json-without-sql-expected.json
+++ b/spring-boot2-test/src/test/resources/testgen-expected/junit5/json-without-sql/json-without-sql-expected.json
@@ -1,1 +1,9 @@
-[{"firstName":"Paul","lastName":"Pogba","team":"Manchester United"},{"firstName":"Antoine","lastName":"Griezman","team":"Barcelona"}]
+[ {
+  "firstName" : "Paul",
+  "lastName" : "Pogba",
+  "team" : "Manchester United"
+}, {
+  "firstName" : "Antoine",
+  "lastName" : "Griezmann",
+  "team" : "Barcelona"
+} ]


### PR DESCRIPTION
format json generated in test files
format json in test files resources
add method assertEqualJsonFiles() to compare json files using ObjectMapper, instead of text based compare
fix typo (missing 'n' in "Antoine Griezmann"'s name)
Closes #17