### PR TITLE
Ability to configure a warning on SQL execution number #8

### DIFF
--- a/doc/database_diagnostics.md
+++ b/doc/database_diagnostics.md
@@ -240,7 +240,8 @@ GET 200 http://localhost:8080/owners?lastName=
 
 You have to configure two properties to spot long SQL queries.
 
-The
+:wrench: .properties configuration
+
 ```properties
 quickperf.database.sql.execution-time.detected
 ```
@@ -297,4 +298,57 @@ GET 200 http://localhost:8080/owners?lastName=
             on owner0_.id=pets1_.owner_id 
     where
         owner0_.last_name like ?"], Params:[(%)]
+```
+
+### Execution Threshold
+
+:wrench: _.properties_ configuration example
+
+You have to configure two properties to set a threshold to SQL executions.
+The default value for this threshold is 10 sql executions.
+
+:wrench: .properties configuration
+```properties
+quickperf.database.sql.execution.detected=true
+quickperf.database.sql.execution.threshold=10
+```
+:wrench: YAML configuration example
+
+```yaml
+quickperf:
+  database:
+    sql:
+      execution:
+        detected: true
+        threshold: 10
+```
+:wrench: MBean configuration
+
+```
+QuickPerf
+  -- Database
+      -- Operations
+           -- boolean isSqlExecutionDetected()
+           -- void setSqlExecutionDetected(boolean)
+           -- int getSqlExecutionThreshold()
+           -- void setSqlExecutionThreshold(int)
+```
+
+:mag_right: Log example
+```
+2022-10-19 15:09:16.100 INFO 68225 --- [ restartedMain] o.q.s.s.ASpringBootApplication : Started ASpringBootApplication in 7.06 seconds (JVM running for 9.127)
+Hibernate: select player0_.id as id1_0_, player0_.first_name as first_na2_0_, player0_.last_name as last_nam3_0_, player0_.team_id as team_id4_0_ from player player0_
+Hibernate: select player0_.id as id1_0_, player0_.first_name as first_na2_0_, player0_.last_name as last_nam3_0_, player0_.team_id as team_id4_0_ from player player0_
+Hibernate: select player0_.id as id1_0_, player0_.first_name as first_na2_0_, player0_.last_name as last_nam3_0_, player0_.team_id as team_id4_0_ from player player0_
+Hibernate: select player0_.id as id1_0_, player0_.first_name as first_na2_0_, player0_.last_name as last_nam3_0_, player0_.team_id as team_id4_0_ from player player0_
+Hibernate: select player0_.id as id1_0_, player0_.first_name as first_na2_0_, player0_.last_name as last_nam3_0_, player0_.team_id as team_id4_0_ from player player0_
+Hibernate: select player0_.id as id1_0_, player0_.first_name as first_na2_0_, player0_.last_name as last_nam3_0_, player0_.team_id as team_id4_0_ from player player0_
+Hibernate: select player0_.id as id1_0_, player0_.first_name as first_na2_0_, player0_.last_name as last_nam3_0_, player0_.team_id as team_id4_0_ from player player0_
+Hibernate: select player0_.id as id1_0_, player0_.first_name as first_na2_0_, player0_.last_name as last_nam3_0_, player0_.team_id as team_id4_0_ from player player0_
+Hibernate: select player0_.id as id1_0_, player0_.first_name as first_na2_0_, player0_.last_name as last_nam3_0_, player0_.team_id as team_id4_0_ from player player0_
+Hibernate: select player0_.id as id1_0_, player0_.first_name as first_na2_0_, player0_.last_name as last_nam3_0_, player0_.team_id as team_id4_0_ from player player0_
+Hibernate: select team0_.id as id1_1_0_, team0_.name as name2_1_0_ from team team0_ where team0_.id=?
+2022-10-19 15:10:38.899 WARN 68225 --- [tp1496937262-36] s.QuickPerfHttpCallHttpCallWarningLogger :
+GET 200 http://localhost:8080/json-with-n-plus-one-select
+* [WARNING] You have reached your SQL executions threshold : 11 > 10
 ```

--- a/spring-boot-2/src/main/java/org/quickperf/web/spring/QuickPerfAfterRequestServletFilter.java
+++ b/spring-boot-2/src/main/java/org/quickperf/web/spring/QuickPerfAfterRequestServletFilter.java
@@ -180,7 +180,7 @@ public class QuickPerfAfterRequestServletFilter implements Filter {
         SqlExecutionsRecorder sqlExecutionsRecorder = SqlRecorderRegistry.INSTANCE.getSqlRecorderOfType(SqlExecutionsRecorder.class);
 
         SqlExecutions sqlExecutions = null;
-        if (databaseConfig.isSqlDisplayed() || databaseConfig.isNPlusOneSelectDetected()) {
+        if (databaseConfig.isSqlDisplayed() || databaseConfig.isNPlusOneSelectDetected() || databaseConfig.isSqlExecutionDetected() ) {
             sqlExecutions = sqlExecutionsRecorder.findRecord(null);
         }
 
@@ -238,6 +238,16 @@ public class QuickPerfAfterRequestServletFilter implements Filter {
                 if (selectNumber.shortValue() >= databaseConfig.getNPlusOneSelectDetectionThreshold()) {
                     warnReport.append(lineSeparator() + "\t* [WARNING] N+1 select suspicion" + " - " + selectNumber + " SELECT");
                 }
+            }
+
+        }
+
+        if(databaseConfig.isSqlExecutionDetected()) {
+            int sqlExecutionThreshold = databaseConfig.getSqlExecutionThreshold();
+            int numberOfExecutions = sqlExecutions.getNumberOfExecutions();
+
+            if(numberOfExecutions > sqlExecutionThreshold){
+                warnReport.append(lineSeparator() + "\t* [WARNING] You have reached your SQL executions threshold" + " : " + numberOfExecutions + " > " + sqlExecutionThreshold);
             }
 
         }

--- a/spring-boot-2/src/main/java/org/quickperf/web/spring/QuickPerfBeforeRequestServletFilter.java
+++ b/spring-boot-2/src/main/java/org/quickperf/web/spring/QuickPerfBeforeRequestServletFilter.java
@@ -133,7 +133,7 @@ public class QuickPerfBeforeRequestServletFilter implements Filter {
 
 	private void quickPerfProcessing() {
 
-		if(databaseConfig.isSqlDisplayed() || databaseConfig.isNPlusOneSelectDetected()) {
+		if(databaseConfig.isSqlDisplayed() || databaseConfig.isNPlusOneSelectDetected() || databaseConfig.isSqlExecutionDetected()) {
 			SqlRecorderRegistry.INSTANCE.register(new SqlExecutionsRecorder());
 		}
 

--- a/spring-boot-2/src/main/java/org/quickperf/web/spring/config/DatabaseConfig.java
+++ b/spring-boot-2/src/main/java/org/quickperf/web/spring/config/DatabaseConfig.java
@@ -45,6 +45,13 @@ public class DatabaseConfig {
 	@Value("${quickperf.database.sql.execution-time.thresholdInMs:0}")
 	private int sqlExecutionTimeThresholdInMilliseconds;
 
+	@Value("${quickperf.database.sql.execution.detected:false}")
+	private boolean sqlExecutionDetected;
+
+	@Value("${quickperf.database.sql.execution.threshold:10}")
+	private int sqlExecutionThreshold;
+
+
 	@ManagedAttribute
 	public boolean isNPlusOneSelectDetected() {
 		return nPlusOneSelectDetected;
@@ -115,4 +122,20 @@ public class DatabaseConfig {
 		this.sqlDisplayed = sqlDisplayed;
 	}
 
+	@ManagedAttribute
+	public boolean isSqlExecutionDetected() {
+		return this.sqlExecutionDetected;
+	}
+	@ManagedOperation
+	public void setSqlExecutionDetected(boolean sqlExecutionDetected){
+		this.sqlExecutionDetected = sqlExecutionDetected;
+	}
+	@ManagedAttribute
+	public int getSqlExecutionThreshold(){
+		return this.sqlExecutionThreshold;
+	}
+	@ManagedOperation
+	public void setSqlExecutionThreshold(int threshold){
+		this.sqlExecutionThreshold = threshold;
+	}
 }

--- a/spring-boot-2/src/test/java/config/mbean/QuickPerfMBeansTest.java
+++ b/spring-boot-2/src/test/java/config/mbean/QuickPerfMBeansTest.java
@@ -86,7 +86,9 @@ public class QuickPerfMBeansTest {
                                         , "SelectedColumnsDisplayed"
                                         , "SqlDisplayed"
                                         , "SqlExecutionTimeDetected"
-                                        , "SqlExecutionTimeThresholdInMilliseconds");
+                                        , "SqlExecutionTimeThresholdInMilliseconds"
+                                        , "SqlExecutionDetected"
+                                        , "SqlExecutionThreshold");
 
                     assertThat(databaseConfigMBeanInfo.getOperations()).isNotNull();
 

--- a/spring-boot2-test/src/test/java/messages/warning/SqlExecutionDetectionThresholdRaisedTest.java
+++ b/spring-boot2-test/src/test/java/messages/warning/SqlExecutionDetectionThresholdRaisedTest.java
@@ -1,0 +1,40 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2021-2021 the original author or authors.
+ */
+
+package messages.warning;
+
+import messages.util.TestQuickPerfMessages;
+import messages.util.TestableQuickPerfMessage;
+import org.junit.jupiter.api.Test;
+
+import static messages.util.QuickPerfMessagesAssert.assertThat;
+import static org.quickperf.spring.springboottest.controller.HttpUrl.JSON_WITH_N_PLUS_ONE_SELECT;
+
+public class SqlExecutionDetectionThresholdRaisedTest extends TestQuickPerfMessages {
+    @Test
+    public void
+    should_warn_when_number_of_sql_executions_exceeds_threshold() {
+
+        databaseConfig.setSqlExecutionDetected(true);
+        short sqlExecutionDetectionThreshold = 2;
+        databaseConfig.setSqlExecutionThreshold(sqlExecutionDetectionThreshold);
+
+        performGetOnUrlReturningJson(JSON_WITH_N_PLUS_ONE_SELECT);
+
+        TestableQuickPerfMessage quickPerfWarnings = warningInterceptor.getWarnings();
+
+        assertThat(quickPerfWarnings)
+                .hasAMessageContaining("You have reached your SQL executions threshold");
+
+    }
+}


### PR DESCRIPTION
I ve tested it manually with the following properties :
quickperf.database.operations.sqlExecutionDetected=true
quickperf.database.operations.sqlExecutionThreshold=1

and it gave this
2022-10-19 15:09:16.100  INFO 68225 --- [  restartedMain] o.q.s.s.ASpringBootApplication           : Started ASpringBootApplication in 7.06 seconds (JVM running for 9.127)
Hibernate: select player0_.id as id1_0_, player0_.first_name as first_na2_0_, player0_.last_name as last_nam3_0_, player0_.team_id as team_id4_0_ from player player0_
Hibernate: select player0_.id as id1_0_, player0_.first_name as first_na2_0_, player0_.last_name as last_nam3_0_, player0_.team_id as team_id4_0_ from player player0_
Hibernate: select team0_.id as id1_1_0_, team0_.name as name2_1_0_ from team team0_ where team0_.id=?
2022-10-19 15:10:38.899  WARN 68225 --- [tp1496937262-36] s.QuickPerfHttpCallHttpCallWarningLogger : 
GET 200 http://localhost:8080/json-with-n-plus-one-select
	* [WARNING] You have reached your SQL executions threshold - 2 > 1


do not hesitate to give me any hints to improve the code or test coverage..